### PR TITLE
Fix incorrect SAT results on Linux/ARM where "char" is unsigned.

### DIFF
--- a/Solver.C
+++ b/Solver.C
@@ -239,7 +239,7 @@ void Solver::cancelUntil(int level) {
 void Solver::analyze(Clause* _confl, vec<Lit>& out_learnt, int& out_btlevel)
 {
     GClause confl = GClause_new(_confl);
-    vec<char>&     seen  = analyze_seen;
+    vec<int8_t>&   seen  = analyze_seen;
     int            pathC = 0;
     Lit            p     = lit_Undef;
 
@@ -371,7 +371,7 @@ void Solver::analyzeFinal(Clause* confl, bool skip_first)
     conflict.clear();
     if (root_level == 0) return;
 
-    vec<char>&     seen  = analyze_seen;
+    vec<int8_t>& seen = analyze_seen;
     for (int i = skip_first ? 1 : 0; i < confl->size(); i++){
         Var     x = var((*confl)[i]);
         if (level[x] > 0)

--- a/Solver.h
+++ b/Solver.h
@@ -63,7 +63,7 @@ protected:
     VarOrder            order;            // Keeps track of the decision variable order.
 
     vec<vec<GClause> >  watches;          // 'watches[lit]' is a list of constraints watching 'lit' (will go there if literal becomes true).
-    vec<char>           assigns;          // The current assignments (lbool:s stored as char:s).
+    vec<int8_t>         assigns;          // The current assignments (lbool:s stored as int8_t:s).
     vec<Lit>            trail;            // Assignment stack; stores all assigments made in the order they were made.
     vec<int>            trail_lim;        // Separator indices for different decision levels in 'trail'.
     vec<GClause>        reason;           // 'reason[var]' is the clause that implied the variables current value, or 'NULL' if none.
@@ -75,7 +75,7 @@ protected:
 
     // Temporaries (to reduce allocation overhead). Each variable is prefixed by the method in which is used:
     //
-    vec<char>           analyze_seen;
+    vec<int8_t>         analyze_seen;
     vec<Lit>            analyze_stack;
     vec<Lit>            analyze_toclear;
     Clause*             propagate_tmpbin;

--- a/SolverTypes.h
+++ b/SolverTypes.h
@@ -98,7 +98,7 @@ public:
 inline Clause* Clause_new(bool learnt, const vec<Lit>& ps) {
     assert(sizeof(Lit)      == sizeof(uint));
     assert(sizeof(float)    == sizeof(uint));
-    void*   mem = xmalloc<char>(sizeof(Clause) - sizeof(Lit) + sizeof(uint)*(ps.size() + (int)learnt));
+    void*   mem = xmalloc<int8_t>(sizeof(Clause) - sizeof(Lit) + sizeof(uint)*(ps.size() + (int)learnt));
     return new (mem) Clause(learnt, ps); }
 
 

--- a/VarOrder.h
+++ b/VarOrder.h
@@ -34,13 +34,13 @@ struct VarOrder_lt {
 };
 
 class VarOrder {
-    const vec<char>&    assigns;     // var->val. Pointer to external assignment table.
+    const vec<int8_t>&  assigns;     // var->val. Pointer to external assignment table.
     const vec<double>&  activity;    // var->act. Pointer to external activity table.
     Heap<VarOrder_lt>   heap;
     double              random_seed; // For the internal random number generator
 
 public:
-    VarOrder(const vec<char>& ass, const vec<double>& act) :
+    VarOrder(const vec<int8_t>& ass, const vec<double>& act) :
         assigns(ass), activity(act), heap(VarOrder_lt(act)), random_seed(91648253)
         { }
 


### PR DESCRIPTION
In line 428 of Solver.C, the statement 
```
assigns[var(p)] = toInt(lbool(!sign(p)));
```
causes implementation-specific behavior when assigning a possibly negative value to a array slot of char, which is unsigned on Linux/ARM (with common C compilers like GCC and LLVM clang).

This was found by Oskar Abrahamsson (@oskarabrahamsson) of HOL community by using the UndefinedBehaviorSanitizer (UBSan) [1] from LLVM project.

[1] https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html